### PR TITLE
Make compatible with activeadmin 2.0

### DIFF
--- a/arctic_admin.gemspec
+++ b/arctic_admin.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"
-  s.add_dependency 'activeadmin', ['>= 1.1.0', '< 2.0']
+  s.add_dependency 'activeadmin', ['>= 1.1.0', '< 2.1']
   s.add_dependency 'jquery-rails'
   s.add_dependency 'font-awesome-sass', '~> 5.6.1'
 end


### PR DESCRIPTION
We have been running arctic_admin 2.0.2 with activeadmin 2.0.0.rc2 and it's looking good.