### PR TITLE
Add yes and no class for status tags

### DIFF
--- a/app/assets/stylesheets/arctic_admin/components/_status_tag.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_status_tag.scss
@@ -6,12 +6,12 @@
   padding: 3px 5px 2px 5px;
   font-size: 0.8em;
   border-radius: $border-radius;
-}
 
-.status_tag.ok, .status_tag.published, .status_tag.complete, .status_tag.completed, .status_tag.green {
-  background-color: $status-tag-background-valid-color;
-}
+  &.ok, &.published, &.complete, &.completed, &.green, &.yes {
+    background-color: $status-tag-background-valid-color;
+  }
 
-.status_tag.cancel, .status_tag.red {
-  background-color: $status-tag-background-error-color;
+  &.cancel, &.red, &.no {
+    background-color: $status-tag-background-error-color;
+  }
 }


### PR DESCRIPTION
On index pages boolean columns are rendered by ActiveAdmin like this:
`<span class="status_tag yes">Yes</span>`

The current implementation does not include the yes/no classes for the status tag, which is why they appear in the default grey color.

My PR adds those classes and also restructures the SCSS to reduce repetition of the parent selector.