### PR TITLE
Tweak gemspec to allow older versions of active-admin to use this theme.

### DIFF
--- a/app/assets/stylesheets/arctic_admin/_common.scss
+++ b/app/assets/stylesheets/arctic_admin/_common.scss
@@ -4,3 +4,9 @@ code {
   padding: 5px;
   color: white;
 }
+
+hr {
+  border: 1px solid $primary-color;  // $border-color;
+  color: $primary-color;  // $border-color;
+  margin: 10px auto 25px auto;
+}

--- a/app/assets/stylesheets/arctic_admin/components/_tabs.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_tabs.scss
@@ -2,11 +2,11 @@
   border: 1px solid $border-color;
 
   .nav {
-    text-align: center;
     border-bottom: 1px solid $border-color;
     
     li {
       display: inline-block;
+      text-align: center;
       @include outline();
 
       a {

--- a/app/assets/stylesheets/arctic_admin/layouts/_filter.scss
+++ b/app/assets/stylesheets/arctic_admin/layouts/_filter.scss
@@ -22,7 +22,7 @@
     }
 
     .input {
-      margin-bottom: 15px;
+      margin-bottom: 10px;
 
       input, select {
         height: 30px;

--- a/app/assets/stylesheets/arctic_admin/pages/_index.scss
+++ b/app/assets/stylesheets/arctic_admin/pages/_index.scss
@@ -76,13 +76,16 @@ body.index {
   }
 
   .table_actions {
+    margin-bottom: -4px;
+
     .member_link {
       @include primary-button($primary-color, white);
-      padding: 2px 9px;
+      padding: 4px 8px;
       margin-right: 4px;
+      margin-bottom: 4px;
     }
   }
-  
+
   .scopes {
     .scope {
       @include group-button($primary-color);

--- a/arctic_admin.gemspec
+++ b/arctic_admin.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"
-  s.add_dependency 'activeadmin', '~> 2.0'
+  s.add_dependency 'activeadmin', ['>= 1.1.0', '< 3.0']
   s.add_dependency 'jquery-rails'
   s.add_dependency 'font-awesome-sass', '~> 5.6.1'
 end

--- a/lib/arctic_admin/version.rb
+++ b/lib/arctic_admin/version.rb
@@ -1,3 +1,3 @@
 module ArcticAdmin
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
I think there's no specific reason why this theme now requires Active Admin v.2 when it still works properly with older versions.
Tweaked gemspec to allow older versions of Active Admin to keep using this theme.

Update: Did some tweaks to UI elements, nothing major but overall better experience for the user.