### PR TITLE
tabs array empty condition handled.

### DIFF
--- a/app/assets/javascripts/arctic_admin/main.js
+++ b/app/assets/javascripts/arctic_admin/main.js
@@ -41,9 +41,8 @@ $(function () {
   var animationDone = true
   $(document).on('click touchstart', '#utility_nav', function (e) {
     var position = $(this).position()
-    var tabs = $('#tabs')
-    var width = Math.round(tabs[0].getBoundingClientRect().width)
-
+    var tabs = $('#tabs')    
+    var width = (tabs.length==0)? 0 : Math.round(tabs[0].getBoundingClientRect().width)    
     if (e.pageX < position.left + 40) {
       if (animationDone == true) {
         animationDone = false
@@ -73,8 +72,8 @@ $(function () {
   })
 
   $(document).on('click touchstart', 'body', function (e) {
-    var tabs = $('#tabs')
-    var width = Math.round(tabs[0].getBoundingClientRect().width)
+    var tabs = $('#tabs')    
+    var width = (tabs.length==0)? 0 : Math.round(tabs[0].getBoundingClientRect().width)    
     if (tabs.css('left') == '0px') {
       if (e.pageX > width && e.pageY > 60) {
         if (animationDone == true) {

--- a/app/assets/javascripts/arctic_admin/main.js
+++ b/app/assets/javascripts/arctic_admin/main.js
@@ -72,8 +72,8 @@ $(function () {
   })
 
   $(document).on('click touchstart', 'body', function (e) {
-    var tabs = $('#tabs')    
-    var width = (tabs.length==0)? 0 : Math.round(tabs[0].getBoundingClientRect().width)    
+    var tabs = $('#tabs')
+    var width = (tabs.length==0)? 0 : Math.round(tabs[0].getBoundingClientRect().width)
     if (tabs.css('left') == '0px') {
       if (e.pageX > width && e.pageY > 60) {
         if (animationDone == true) {


### PR DESCRIPTION
The tabs array can be empty in which case, the getBoundingClientRect() function returns an error. This is taken care of by setting the width to zero when the tabs array is empty.