### PR TITLE
Enforce checbox default background color

### DIFF
--- a/app/assets/stylesheets/arctic_admin/components/_inputs.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_inputs.scss
@@ -62,7 +62,7 @@ input[type="checkbox"] {
 
   &:checked {
     border-color: $primary-color;
-    background-color: $primary-color;
+    background-color: $primary-color !important;
   }
 }
 


### PR DESCRIPTION
In case validation fails on a checkbox input,

https://github.com/cprodhomme/arctic_admin/blob/76af378f4fda01783a838d9ea157ce82a6bc6b3b/app/assets/stylesheets/arctic_admin/components/_form.scss#L29-L33

overwrites the default colour for `:checked` pseudo-class. As a result, checking only works internally but no visual change can be seen.

this PR should enforce the default background colour on checked state even when a validation fails on the checkbox input.