### PR TITLE
fix toggle of nested menu items

### DIFF
--- a/app/assets/javascripts/arctic_admin/main.js
+++ b/app/assets/javascripts/arctic_admin/main.js
@@ -39,12 +39,14 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   // toggle of nested menu items
-  const nestedMenuItem = document.querySelector('#tabs .has_nested')
-  if (nestedMenuItem) {
-    nestedMenuItem.addEventListener('click', (e) => {
-      e.stopPropagation()
-      nestedMenuItem.classList.toggle('open')
-    })
-  }
+  const nestedMenuItems = document.querySelectorAll('#tabs .has_nested')
+  nestedMenuItems.forEach(
+    (nestedMenuItem) => {
+      nestedMenuItem.addEventListener('click', (e) => {
+        e.stopPropagation()
+        nestedMenuItem.classList.toggle('open')
+      })
+    }
+  )
 
 })


### PR DESCRIPTION
- there may exists multiple nested menu items.
- but querySelector only select single item.
- thus, changed querySelector to querySelectorAll to select all nestedMenuItems
- also loop for items and add event listener to each of them