### PR TITLE
Remove deprecation warning for font size division

### DIFF
--- a/app/assets/stylesheets/arctic_admin/pages/_index.scss
+++ b/app/assets/stylesheets/arctic_admin/pages/_index.scss
@@ -66,7 +66,7 @@ body.index {
       @include transform(translateY(-50%));
 
       @media screen and (min-width: $md-width) {
-        font-size: $font-size/1;
+        font-size: $font-size;
       }
     }
 


### PR DESCRIPTION
I am getting this warning 

```
assets | DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
assets | 
assets | Recommendation: math.div($font-size, 1)
assets | 
assets | More info and automated migrator: https://sass-lang.com/d/slash-div
assets | 
assets |    ╷
assets | 69 │         font-size: $font-size/1;
assets |    │                    ^^^^^^^^^^^^
assets |    ╵
assets |     node_modules/arctic_admin/src/scss/pages/_index.scss 69:20  @import
assets |     node_modules/arctic_admin/src/scss/_main.scss 33:9          @import
assets |     app/javascript/stylesheets/active_admin.scss 13:9           root stylesheet
```

This patch removes an unnecessary division by 1