### PR TITLE
Remove font-awesome-sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ config.meta_tags = meta_tags_options
 config.meta_tags_for_logged_out_pages = meta_tags_options
 ```
 
-## Usage
+## Use with Sprockets
 
-### CSS
+### 1 - Preparation
+
+Install the needed assets with Gemfile:
+
+```ruby
+gem 'font-awesome-sass', '~> 5.0'
+```
+
+### 2a - CSS
 
 In your `active_admin.css`, include the css file:
 
@@ -48,7 +56,7 @@ In your `active_admin.css`, include the css file:
 
 Then restart your webserver if it was previously running.
 
-### Sass Support
+### 2b - Sass Support
 
 :exclamation: **Remove the line `@import "active_admin/base"`**
 
@@ -67,7 +75,7 @@ add this to your `active_admin.sass` file:
 @import arctic_admin/base
 ```
 
-### JS
+### 3 - JS
 
 In your `active_admin.js`, include the js file:
 

--- a/arctic_admin.gemspec
+++ b/arctic_admin.gemspec
@@ -16,5 +16,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"
   s.add_dependency 'activeadmin', ['>= 1.1.0', '< 3.0']
-  s.add_dependency 'font-awesome-sass', '~> 5.0'
 end

--- a/lib/arctic_admin.rb
+++ b/lib/arctic_admin.rb
@@ -1,5 +1,4 @@
 require "arctic_admin/version"
-require 'font-awesome-sass'
 
 module ArcticAdmin
   module Rails


### PR DESCRIPTION
As Rails 7.0 now provides several options to handle CSS assets, we should avoid specifying specific solution for gem users.