### PR TITLE
Add null guard to main.js

### DIFF
--- a/app/assets/javascripts/arctic_admin/main.js
+++ b/app/assets/javascripts/arctic_admin/main.js
@@ -59,7 +59,9 @@ function addListeners() {
   }
 
   // left menu sidebar close on any click outside
-  document.body.addEventListener('click', menuClose)
+  if (menu()) {
+    document.body.addEventListener('click', menuClose)
+  }  
 
   // nested menu items toggle
   nestedMenuItems().forEach(
@@ -81,10 +83,14 @@ function removeListeners() {
   }
 
   // left menu sidebar toggle with menu button
-  menuButton().removeEventListener('click', menuToggle)
+  if (menuButton()) {
+    menuButton().removeEventListener('click', menuToggle)
+  }  
 
   // left menu sidebar close on any click outside
-  document.body.removeEventListener('click', menuClose)
+  if (menu()) {
+    document.body.removeEventListener('click', menuClose)
+  }  
 
   // nested menu items toggle
   nestedMenuItems().forEach(


### PR DESCRIPTION
The login page doesn't contain the #tab and #utility_nav elements. This absence leads to a null reference error. As a solution, I've added a null guard to main.js.