### PR TITLE
🐛 Allows MenuToggle even without the current_user button presence in navbar

### DIFF
--- a/app/assets/javascripts/arctic_admin/main.js
+++ b/app/assets/javascripts/arctic_admin/main.js
@@ -23,7 +23,7 @@ function menuToggle(event) {
   const forbiddenLinks = event.target === logout ||
     logout.contains(event.target) ||
     event.target === currentUser ||
-    currentUser.contains(event.target)
+    currentUser?.contains(event.target)
   if (!forbiddenLinks) {
     menu().classList.toggle('tabs_open')
   }


### PR DESCRIPTION
Hello, this PR is the follow up of [this issue](https://github.com/cprodhomme/arctic_admin/issues/117). 

I'm adding the context below for archive. 

--- 


Hello there 🐥 

First of you, thank you all for your work on this gem ! 

**Describe the bug**
I recently upgraded a Rails 6.1 app with Webpacker from Webpacker v5 to Webpacker v6.

After the migration, active admin remained broken. 

An JS error was occuring: 

    Cannot read properties of null (reading 'contains') menuToggle active admin

After investigation it happened to be linked to [this line](https://github.com/cprodhomme/arctic_admin/blob/fb49229b62196abe2a0b0ab22fcc381cd0ab4754/app/assets/javascripts/arctic_admin/main.js#L26) 

It basically makes `$('#current_user').contains(..)` therefore making the assumption that `#current_user` exists.

_However_ in the active admin gem, we can find that the generation of this nav item is conditionned by the non-overload of the `:utility_navigation`  ([link here](https://github.com/activeadmin/activeadmin/blob/41c24aa498fa4221bdcbb12c47382c0f6d8d6c8f/lib/active_admin/namespace.rb#L191C8-L191C8))

In our app, it happened that active admin allows the customisation of this part of the navbar (see [here](https://github.com/activeadmin/activeadmin/blob/41c24aa498fa4221bdcbb12c47382c0f6d8d6c8f/lib/generators/active_admin/install/templates/active_admin.rb.erb#L248)) and we were using it. 

If at this exact position you do not insert `#current_user` then artic admin fails 😁 

**To Reproduce**
Steps to reproduce the behavior:
1. Create an app with active admin 
2. Adds artic admin 
3. Edit the `config/initializers/active_admin.rb` file to add something unrelated, for instance: 

```rb
menu.add id: "something", priority: 1, html_options: {},
        label: -> { 'Label' },
        url: -> {'#' }
```

4. Visit `/admin` and click the burger icon to open the sidebar menu. This will fail with the given error. 

**Expected behavior**
ArticAdmin should ignore the lack of this nav to compute if the clicked button is forbidden or not. 

**Technical Solution Proposal** 

The incriminated code is the following : 

```js
  // main.js 
  
  menuButton.addEventListener('click', event => {
    const currentUser = document.querySelector('#current_user')
    const logout = document.querySelector('#logout')
    const forbiddenLinks = event.target === logout ||
        logout.contains(event.target) ||
        event.target === currentUser ||
        currentUser.contains(event.target)
    if (!forbiddenLinks) {
      menu.classList.toggle('tabs_open')
    }
  })
  ```

A quick solution would be to ignore the lack of this nav item : 

```diff
  // main.js 
  
  menuButton.addEventListener('click', event => {
    const currentUser = document.querySelector('#current_user')
    const logout = document.querySelector('#logout')
    const forbiddenLinks = event.target === logout ||
        logout.contains(event.target) ||
        event.target === currentUser ||
-        currentUser.contains(event.target)
+        currentUser?.contains(event.target)
    if (!forbiddenLinks) {
      menu.classList.toggle('tabs_open')
    }
  })
  ```

Have a great day 💃🏼 