### PR TITLE
Fix Sass 1.77.7 warnings

### DIFF
--- a/app/assets/stylesheets/arctic_admin/_buttons.scss
+++ b/app/assets/stylesheets/arctic_admin/_buttons.scss
@@ -1,7 +1,7 @@
 .button {
-  @include primary-button($primary-color, #fff);
   padding: 5px 8px;
   font-size: 16px;
+  @include primary-button($primary-color, #fff);
 
   &.small {
     padding: 2px 9px;

--- a/app/assets/stylesheets/arctic_admin/components/_comments.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_comments.scss
@@ -5,7 +5,7 @@
   h3 {
     margin: 0 0 10px 0;
   }
-  
+
   .panel_contents .empty {
     margin-bottom: 10px;
     display: inline-block;
@@ -31,10 +31,10 @@
       }
 
       a[data-method="delete"] {
-        @include primary-button($primary-color, white);
         padding: 2px 9px;
         font-size: 12px;
         float: right;
+        @include primary-button($primary-color, white);
       }
     }
 

--- a/app/assets/stylesheets/arctic_admin/components/_date_picker.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_date_picker.scss
@@ -2,18 +2,18 @@
   background-color: #fff;
   padding: 5px;
   border-radius: $border-radius;
-  @include box-shadow(0 0 4px 0 rgba(0,0,0,.1));
   z-index: 3!important;
   padding: 8px 10px;
+  @include box-shadow(0 0 4px 0 rgba(0,0,0,.1));
 
   .ui-datepicker-header {
-    @include clear-fix();
     margin-bottom: 10px;
+    @include clear-fix();
 
     .ui-datepicker-prev, .ui-datepicker-next {
-      @include primary-button($button-primary-color, #fff);
       padding: 2px 5px;
       font-size: 14px;
+      @include primary-button($button-primary-color, #fff);
     }
 
     .ui-datepicker-prev {

--- a/app/assets/stylesheets/arctic_admin/components/_dialogs.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_dialogs.scss
@@ -1,9 +1,9 @@
 .ui-dialog {
   background-color: #fff;
-  @include box-shadow($box-shadow);
   border-radius: $border-radius;
   padding: 15px 10px;
   z-index: 1;
+  @include box-shadow($box-shadow);
 
   &:focus, &:active {
     -webkit-tap-highlight-color: rgba(0,0,0,0);
@@ -11,10 +11,10 @@
   }
 
   .ui-button {
-    @include primary-button($primary-color, #fff);
-    border: 0;
+    border: none;
     margin-right: 5px;
     padding: 5px 10px;
+    @include primary-button($primary-color, #fff);
   }
 
   .ui-dialog-titlebar-close {

--- a/app/assets/stylesheets/arctic_admin/components/_inputs.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_inputs.scss
@@ -38,7 +38,6 @@ input[type="number"], textarea {
 
 input[type="submit"] {
   @include appearance();
-  @include primary-button($button-primary-color, white);
   width: 100%;
   padding: 0 12px;
   font-size: 15px;
@@ -46,6 +45,7 @@ input[type="submit"] {
   @include box-shadow(0 1px 0 rgba(0,0,0,.05));
   border: none;
   cursor: pointer;
+  @include primary-button($button-primary-color, white);
 }
 
 input[type="checkbox"] {
@@ -56,9 +56,9 @@ input[type="checkbox"] {
   border: 1px solid #e6e6e6;
   border-radius: $border-radius;
   box-sizing: border-box;
-  @include outline();
-  @include transition-button();
   cursor: pointer;
+  @include transition-button();
+  @include outline();
 
   &:checked {
     border-color: $primary-color;
@@ -74,8 +74,8 @@ input[type="radio"] {
   border-radius: 50%;
   margin: 1px 5px 1px 1px;
   display: inline-flex;
-  @include outline();
   @include transition-button();
+  @include outline();
 
   &:checked {
     background-color: $primary-color;

--- a/app/assets/stylesheets/arctic_admin/components/_tabs.scss
+++ b/app/assets/stylesheets/arctic_admin/components/_tabs.scss
@@ -3,7 +3,7 @@
 
   .nav {
     border-bottom: 1px solid $border-color;
-    
+
     li {
       display: inline-block;
       text-align: center;
@@ -13,10 +13,10 @@
         color: $text-color;
         display: inline-block;
         padding: 15px 25px;
-        @include outline();
         @include transition-button();
+        @include outline();
       }
-      
+
       &.ui-tabs-active {
         border-bottom: 2px solid $link-primary-color;
 

--- a/app/assets/stylesheets/arctic_admin/layouts/_header.scss
+++ b/app/assets/stylesheets/arctic_admin/layouts/_header.scss
@@ -47,7 +47,7 @@ body.active_admin.logged_in {
     @media screen and (min-width: $x-lg-width) {
       width: $lg-header-width;
     }
-    
+
     #site_title_image {
       height: 100%;
       padding: 6px 0;
@@ -180,7 +180,7 @@ body.active_admin.logged_in {
         }
 
       }
-      
+
       @media screen and (min-width: $sm-width) {
         min-width: 60px;
         min-height: 59px;
@@ -228,8 +228,8 @@ body.active_admin.logged_in {
     float: right;
 
     .action_item a {
-      @include primary-button($button-primary-color, #fff);
       padding: 5px 8px;
+      @include primary-button($button-primary-color, #fff);
     }
   }
 

--- a/app/assets/stylesheets/arctic_admin/mixins/_buttons_mixins.scss
+++ b/app/assets/stylesheets/arctic_admin/mixins/_buttons_mixins.scss
@@ -20,7 +20,7 @@ $bg-tertiary-button-hover: rgba($border-color, .3);;
 @mixin primary-button($background-color, $color) {
   background-color: $background-color;
   color: $color;
-  border: none; 
+  border: none;
   @include button();
 
   &:hover {
@@ -28,7 +28,7 @@ $bg-tertiary-button-hover: rgba($border-color, .3);;
   }
 
   &:active, &:focus {
-    background-color: darken($background-color, 10%); 
+    background-color: darken($background-color, 10%);
   }
 
   &:disabled {
@@ -73,9 +73,12 @@ $bg-tertiary-button-hover: rgba($border-color, .3);;
 }
 
 @mixin secondary-dropdown($color) {
-  @include secondary-button($color);
-  padding: 6px 25px 6px 10px;
   position: relative;
+  @include secondary-button($color);
+
+  & {
+    padding: 6px 25px 6px 10px; // Preserve padding on Sass > 1.77.6 (See cprodhomme/arctic_admin#123)
+  }
 
   &:after {
     @include icon($icon-sort-down);
@@ -84,7 +87,7 @@ $bg-tertiary-button-hover: rgba($border-color, .3);;
   }
 
   &:active, &:focus {
-    background-color: darken($color, 10%); 
+    background-color: darken($color, 10%);
     color: #fff;
   }
 

--- a/app/assets/stylesheets/arctic_admin/pages/_index.scss
+++ b/app/assets/stylesheets/arctic_admin/pages/_index.scss
@@ -97,10 +97,10 @@ body.index {
     margin-bottom: -4px;
 
     .member_link {
-      @include primary-button($button-primary-color, white);
       padding: 4px 8px;
       margin-right: 4px;
       margin-bottom: 4px;
+      @include primary-button($button-primary-color, white);
     }
   }
 


### PR DESCRIPTION
- Use `border: none;` for uniformity and to prevent two rules to be added to `.ui-dialog .ui-button`
- Fix `secondary-dropdown` mixin to preserve its padding

Close #123

---

Please do a manual test